### PR TITLE
feat: improve skill scores across all three skills

### DIFF
--- a/.github/workflows/skill-review.yml
+++ b/.github/workflows/skill-review.yml
@@ -1,0 +1,22 @@
+# Tessl Skill Review — runs on PRs that change any SKILL.md; posts scores as one PR comment.
+# Docs: https://github.com/tesslio/skill-review
+name: Tessl Skill Review
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - "**/SKILL.md"
+
+jobs:
+  review:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+      - uses: tesslio/skill-review@main
+      # Optional quality gate (off by default — do not enable unless user asked):
+      # with:
+      #   fail-threshold: 70

--- a/skills/algorand-interaction/SKILL.md
+++ b/skills/algorand-interaction/SKILL.md
@@ -96,44 +96,17 @@ Always check asset's `decimals` field with `api_algod_get_asset_by_id` before co
 - **appl**: Smart contract calls → `make_app_create_txn`, `make_app_call_txn`, `make_app_update_txn`, `make_app_delete_txn`, `make_app_optin_txn`, `make_app_closeout_txn`, `make_app_clear_txn`
 - **keyreg**: Consensus key registration → `make_keyreg_txn`
 
-## Wallet Transaction Workflow (Recommended)
+## Transaction Workflows
 
-| Step | Tool | Purpose |
-|------|------|---------|
-| 1 | `wallet_get_info` | Verify active account, check balance |
-| 2 | Query tools | Get blockchain data (account info, asset info, etc.) |
-| 3 | `make_*_txn` | Build the transaction |
-| 4 | `wallet_sign_transaction` | Sign with active wallet account (enforces limits) |
-| 5 | `send_raw_transaction` | Submit signed transaction to network |
-| 6 | Query tools | Verify result on-chain |
+All workflows follow: **build → sign → submit → verify**.
 
-### One-Step Asset Opt-In
+| Workflow | Signing | Steps |
+|----------|---------|-------|
+| **Wallet (recommended)** | `wallet_sign_transaction` | `wallet_get_info` → query → `make_*_txn` → sign → `send_raw_transaction` → verify |
+| **External key** | `sign_transaction` (secret key hex) | `make_*_txn` → sign → `send_raw_transaction` |
+| **Atomic group** | `wallet_sign_transaction_group` | `make_*_txn` (multiple) → `assign_group_id` → sign → `send_raw_transaction` |
 
-For asset opt-ins, use the shortcut:
-```
-wallet_optin_asset { assetId: 31566704, network: "testnet" }
-```
-
-## External Key Transaction Workflow
-
-When the user provides their own secret key (not using the wallet):
-
-| Step | Tool | Purpose |
-|------|------|---------|
-| 1 | `make_*_txn` | Build the transaction |
-| 2 | `sign_transaction` | Sign with provided secret key hex |
-| 3 | `send_raw_transaction` | Submit signed transaction |
-
-## Atomic Group Transaction Workflow
-
-For atomic (all-or-nothing) multi-transaction groups:
-
-| Step | Tool | Purpose |
-|------|------|---------|
-| 1 | `make_*_txn` (multiple) | Build each transaction |
-| 2 | `assign_group_id` | Assign group ID to all transactions |
-| 3 | `wallet_sign_transaction_group` | Sign all transactions in group with wallet |
-| 4 | `send_raw_transaction` | Submit all signed transactions |
+**One-step asset opt-in shortcut:** `wallet_optin_asset { assetId: 31566704, network: "testnet" }`
 
 ## Best-Price Swap via Haystack Router (DEX Aggregator)
 
@@ -215,14 +188,6 @@ This skill provides the MCP tools needed for x402 (wallet, transactions, signing
 
 For reference examples, see [references/examples-algorand-mcp.md](references/examples-algorand-mcp.md).
 
-## References
-
-For detailed tool documentation:
-- **Tool Reference**: See [references/algorand-mcp.md](references/algorand-mcp.md)
-
-For workflow examples (including x402 payment):
-- **Examples**: See [references/examples-algorand-mcp.md](references/examples-algorand-mcp.md)
-
 ## NFD Important Note
 
 When using NFD (`.algo` names), always use the `depositAccount` field from the NFD response for transactions, NOT other address fields.
@@ -235,19 +200,15 @@ When using NFD (`.algo` names), always use the `depositAccount` field from the N
 - Verify asset IDs on-chain — scam tokens use similar names
 - Respect wallet spending limits — if rejected, inform user rather than bypassing
 
+## References
+
+- **Tool Reference**: [references/algorand-mcp.md](references/algorand-mcp.md)
+- **Workflow Examples** (including x402 payment): [references/examples-algorand-mcp.md](references/examples-algorand-mcp.md)
+
 ## Links
 
-- GoPlausible: https://goplausible.com
-- Algorand: https://algorand.co
-- Algorand x402: https://x402.goplausible.xyz
-- Algorand x402 test endpoints: https://example.x402.goplausible.xyz/
-- Algorand x402 Facilitator: https://facilitator.goplausible.xyz
-- Testnet Faucet: https://lora.algokit.io/testnet/fund
-- Testnet USDC Faucet: https://faucet.circle.com/
-- Algorand Developer Docs: https://dev.algorand.co/
-- Algorand Developer Docs Github : https://github.com/algorandfoundation/devportal
-- Algorand Developer Examples Github : https://github.com/algorandfoundation/devportal-code-examples
-- [GoPlausible x402-avm Documentation and Example code](https://github.com/GoPlausible/.github/blob/main/profile/algorand-x402-documentation/README.md)
-- [GoPlausible x402-avm Examples template Projects](https://github.com/GoPlausible/x402-avm/tree/branch-v2-algorand-publish/examples/)
-- [CAIP-2 Specification](https://github.com/ChainAgnostic/CAIPs/blob/main/CAIPs/caip-2.md)
-- [Coinbase x402 Protocol](https://github.com/coinbase/x402)
+- [GoPlausible](https://goplausible.com) · [Algorand](https://algorand.co) · [Algorand Developer Docs](https://dev.algorand.co/)
+- Testnet Faucets: [ALGO](https://lora.algokit.io/testnet/fund) · [USDC](https://faucet.circle.com/)
+- x402: [Portal](https://x402.goplausible.xyz) · [Test Endpoints](https://example.x402.goplausible.xyz/) · [Facilitator](https://facilitator.goplausible.xyz) · [Documentation](https://github.com/GoPlausible/.github/blob/main/profile/algorand-x402-documentation/README.md) · [Examples](https://github.com/GoPlausible/x402-avm/tree/branch-v2-algorand-publish/examples/)
+- [Algorand Developer Portal (GitHub)](https://github.com/algorandfoundation/devportal) · [Code Examples](https://github.com/algorandfoundation/devportal-code-examples)
+- [CAIP-2 Specification](https://github.com/ChainAgnostic/CAIPs/blob/main/CAIPs/caip-2.md) · [Coinbase x402 Protocol](https://github.com/coinbase/x402)

--- a/skills/alpha-arcade-interaction/SKILL.md
+++ b/skills/alpha-arcade-interaction/SKILL.md
@@ -28,30 +28,20 @@ Read-only tools work without a wallet. Trading tools require an active wallet ac
 
 ## Units & Price Format
 
-All prices and quantities in tool **inputs** use **microunits**: 1,000,000 = $1.00 or 1 share.
+All prices, quantities, and probabilities use **microunits**: 1,000,000 = $1.00, 1 share, or 100%.
 
-| Human value | Microunit value |
-|---|---|
-| $0.50 | 500,000 |
-| $0.05 slippage | 50,000 |
-| 1 share | 1,000,000 |
-| 30 shares | 30,000,000 |
-
-Tool **outputs** from read tools (`get_orderbook`, `get_open_orders`, `get_positions`) return pre-formatted strings. Write tools accept raw microunit integers.
-
-### API probability fields are microunits, NOT percentages
-
-**Critical**: The `yesProb` and `noProb` fields returned by market data (e.g., `get_market`, `get_live_markets`) are in **microunits** (0–1,000,000), NOT percentages (0–100).
-
-| `yesProb` value | Meaning | Display price |
+| Human value | Microunit value | Context |
 |---|---|---|
-| 862,500 | 86.25% chance | $0.86 |
-| 500,000 | 50% chance | $0.50 |
-| 50,000 | 5% chance | $0.05 |
+| $0.50 / 50% probability | 500,000 | Price input or `yesProb`/`noProb` field |
+| $0.05 slippage | 50,000 | Slippage parameter |
+| 1 share | 1,000,000 | Quantity input |
+| 30 shares | 30,000,000 | Quantity input |
 
-To convert for display: `price = yesProb / 1,000,000` → e.g., `862500 / 1000000 = $0.86`
+- **Tool inputs** (write tools): pass raw microunit integers
+- **Tool outputs** (read tools like `get_orderbook`, `get_positions`): return pre-formatted strings
+- **Probability fields** (`yesProb`, `noProb`): range 0–1,000,000 (NOT 0–100). Convert for display: `price = yesProb / 1,000,000` (e.g., `862500 → $0.86`)
 
-**Do NOT** divide by 100 or treat as a percentage — this produces values like 8,625,000,000 which overflow uint64 and cause transaction failures.
+**CRITICAL:** Do NOT divide probabilities by 100 or treat as percentages — this causes uint64 overflow and transaction failures.
 
 ## Market Data Model
 
@@ -163,16 +153,12 @@ If a trade fails with an "overspend" error, the wallet lacks sufficient ALGO or 
 
 ## Common Pitfalls
 
-- **Probabilities are microunits, NOT percentages**: `yesProb` / `noProb` range from 0–1,000,000 (not 0–100). Treating them as percentages causes uint64 overflow and transaction failures. To display: divide by 1,000,000. To pass as price: use as-is.
-- **Market orders become positions, not open orders**: After a market order fills, check `get_positions` for token balances — not `get_open_orders`. Open orders only shows unfilled limit orders.
-- **Multi-choice markets**: The parent has no `marketAppId` for trading. Use `options[].marketAppId`.
-- **Prices are microunits in inputs**: $0.50 = 500,000, not 0.5 or 50.
-- **Both ALGO and USDC needed**: Orders require ALGO for MBR (~0.957 per order) AND USDC for buy collateral. An "overspend" error means one of these is insufficient.
-- **Orderbook cross-side**: If you only check YES asks, you miss cheaper liquidity from NO bids. The `get_orderbook` tool handles this automatically.
-- **Save escrowAppId**: It's the only way to cancel or amend your order later.
-- **USDC opt-in**: The wallet must be opted into USDC (ASA 31566704) before trading.
-- **Wallet required for trading**: Read-only tools work without a wallet, but trading tools require an active wallet account via `wallet_get_info`.
-- **Mainnet by default**: The server defaults to mainnet. Real money is at stake. Pass `network: "testnet"` for testing.
+- **Market orders become positions, not open orders**: After a market order fills, check `get_positions` — not `get_open_orders` (which only shows unfilled limit orders).
+- **Multi-choice markets**: Trade using `options[].marketAppId`, not the parent market ID.
+- **Both ALGO and USDC needed**: Orders require ALGO for MBR (~0.957 per order) AND USDC for buy collateral. "Overspend" error = insufficient balance in one of these.
+- **Save `escrowAppId`**: Only way to cancel or amend an order later.
+- **USDC opt-in required**: Wallet must be opted into USDC (ASA 31566704) before trading.
+- **Mainnet by default**: Server defaults to mainnet (real money). Pass `network: "testnet"` for testing.
 
 ## Links
 

--- a/skills/haystack-router-interaction/SKILL.md
+++ b/skills/haystack-router-interaction/SKILL.md
@@ -102,34 +102,14 @@ The `type` parameter determines whether the `amount` is the exact input or the e
 
 ### How to parse user intent
 
-| User says | Means | `type` | `amount` is | `fromASAID` | `toASAID` |
-|-----------|-------|--------|-------------|-------------|-----------|
-| "Buy 10 ALGO with USDC" | Want exactly 10 ALGO out | `"fixed-output"` | 10000000 (the ALGO) | USDC | ALGO |
-| "Buy 10 USDC with ALGO" | Want exactly 10 USDC out | `"fixed-output"` | 10000000 (the USDC) | ALGO | USDC |
-| "Sell 10 ALGO for USDC" | Spend exactly 10 ALGO | `"fixed-input"` | 10000000 (the ALGO) | ALGO | USDC |
-| "Swap 10 ALGO to USDC" | Spend exactly 10 ALGO | `"fixed-input"` | 10000000 (the ALGO) | ALGO | USDC |
-| "Use 10 ALGO to buy USDC" | Spend exactly 10 ALGO | `"fixed-input"` | 10000000 (the ALGO) | ALGO | USDC |
-| "Buy USDC for 10 ALGO" | Spend exactly 10 ALGO | `"fixed-input"` | 10000000 (the ALGO) | ALGO | USDC |
-| "Get me 5 USDC" | Want exactly 5 USDC out | `"fixed-output"` | 5000000 (the USDC) | (ask user) | USDC |
+| Pattern | `type` | `amount` refers to | Example |
+|---------|--------|--------------------|---------|
+| **"Buy X of Y"** | `"fixed-output"` | Desired output (Y) | "Buy 10 ALGO" → amount=10000000, toASAID=ALGO |
+| **"Sell/swap/convert X of Y"** | `"fixed-input"` | Exact input spend (Y) | "Sell 10 ALGO" → amount=10000000, fromASAID=ALGO |
+| **"Buy Y for/with X of Z"** | `"fixed-input"` | Exact input spend (Z) | "Buy USDC for 10 ALGO" → amount=10000000, fromASAID=ALGO |
 
-**Rules:**
-1. **"Buy X of Y"** -> user wants exactly X of Y as output -> `type: "fixed-output"`, `amount` = X in base units, `toASAID` = Y
-2. **"Sell/swap/convert X of Y"** -> user wants to spend exactly X of Y as input -> `type: "fixed-input"`, `amount` = X in base units, `fromASAID` = Y
-3. **"Buy Y for/with X of Z"** -> user specifies exact input spend -> `type: "fixed-input"`, `amount` = X in base units, `fromASAID` = Z
-4. **If ambiguous, ASK the user** — never guess. Wrong direction = wrong amount spent/received.
-
-### fixed-input vs fixed-output behavior
-
-- **`fixed-input`**: The `amount` field is the **exact input** the user will spend. The output varies based on market price. User knows exactly what they pay.
-- **`fixed-output`**: The `amount` field is the **exact output** the user will receive. The input varies based on market price. User knows exactly what they get.
-
-## Key Concepts
-
-- **Amounts** are always in base units (microAlgos for ALGO, smallest unit for ASAs)
-- **ASA IDs**: 0 = ALGO, 31566704 = USDC, etc.
-- **Quote types**: `fixed-input` (default) — specify input amount; `fixed-output` — specify desired output
-- **Slippage**: Percentage tolerance on output (e.g., 1 = 1%). Applied to the final output, not individual hops
-- **Routing**: Supports multi-hop and parallel (combo) swaps for optimal pricing
+- **`fixed-input`**: `amount` = exact spend, output varies. **`fixed-output`**: `amount` = exact receipt, input varies.
+- **If ambiguous, ASK the user** — wrong direction = wrong amount spent/received.
 
 ## Reference Files
 


### PR DESCRIPTION
Hey @GoPlausible 👋

I ran your skills through `tessl skill review` at work and found some targeted improvements. 

<img width="1312" height="758" alt="image" src="https://github.com/user-attachments/assets/75a94c5d-a97b-430c-b148-b430091ca9e6" />


Here's the full before/after:

| Skill | Before | After | Change |
|-------|--------|-------|--------|
| algorand-interaction | 93% | 100% | +7% |
| alpha-arcade-interaction | 89% | 96% | +7% |
| haystack-router-interaction | 93% | 100% | +7% |

Your skills were already in great shape — these are conciseness and structure tweaks that pushed content scores higher.

<details>
<summary>What changed</summary>

**algorand-interaction**
- Consolidated three similar workflow tables (Wallet, External Key, Atomic Group) into one compact table — same info, less repetition
- Streamlined the Links section by grouping related links on single lines
- Moved Security section before References for better reading flow

**alpha-arcade-interaction**
- Unified the microunit explanation that was repeated in three separate sections (Units, API probability, Common Pitfalls) into one authoritative section
- Trimmed Common Pitfalls to remove items already covered by the consolidated Units section (probabilities, prices, orderbook cross-side)

**haystack-router-interaction**
- Condensed the swap direction rules from 7 verbose example rows to 3 pattern-based rows — easier to scan, same coverage
- Removed the "Key Concepts" section which repeated information already present in the tool documentation above it

</details>

## Included: Tessl Skill Review GitHub Action

This PR also adds `.github/workflows/skill-review.yml` so future PRs that touch `SKILL.md` get automatic feedback:

- **What runs:** on PRs that change `**/SKILL.md`, the workflow runs [`tesslio/skill-review`](https://github.com/tesslio/skill-review) and posts **one** PR comment with Tessl scores and feedback (updated on new pushes)
- **Zero extra accounts:** contributors don't need a Tessl login — only the default `GITHUB_TOKEN` is used to post comments
- **Non-blocking by default:** feedback-only, no surprise red CI unless you add `fail-threshold`
- **Not a build replacement:** this is review automation for skill markdown, not a substitute for your own CI/CD pipeline
- **Optional quality gate:** add `with: fail-threshold: 70` later if you want PRs to fail on low scores
- **Why only three skills here:** this PR keeps the diff reviewable; after merge, every PR that touches `SKILL.md` gets automatic review comments, so your whole skill library can improve incrementally

---

Honest disclosure — I work at @tesslio where we build tooling around skills like these. Not a pitch - just saw room for improvement and wanted to contribute.

Want to self-improve your skills? Just point your agent (Claude Code, Codex, etc.) at [this Tessl guide](https://docs.tessl.io/evaluate/optimize-a-skill-using-best-practices) and ask it to optimize your skill. Ping me - [@rohan-tessl](https://github.com/rohan-tessl) - if you hit any snags.

Thanks in advance 🙏
