### PR TITLE
Add npm package source metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
   "bugs": {
     "url": "https://github.com/GoPlausible/algorand-mcp/issues"
   },
-  "homepage": "https://github.com/GoPlausible/algorand-mcp#readme",  "publishConfig": {
+  "homepage": "https://github.com/GoPlausible/algorand-mcp#readme",
+  "publishConfig": {
     "access": "public"
   },
   "description": "Algorand Model Context Protocol Local Implementation",

--- a/package.json
+++ b/package.json
@@ -1,65 +1,73 @@
 {
-  "name": "@goplausible/algorand-mcp",
-  "version": "4.2.5",
-  "publishConfig": {
-    "access": "public"
-  },
-  "description": "Algorand Model Context Protocol Local Implementation",
-  "type": "module",
-  "scripts": {
-    "build": "tsc && cp -r src/resources/knowledge/taxonomy src/resources/knowledge/taxonomy-categories dist/resources/knowledge/ && chmod +x dist/index.js",
-    "clean": "rm -rf dist",
-    "test": "NODE_OPTIONS='--experimental-vm-modules' jest",
-    "test:e2e": "NODE_OPTIONS='--experimental-vm-modules' jest --config tests/jest.config.e2e.js",
-    "test:all": "npm test && npm run test:e2e",
-    "typecheck": "tsc --noEmit",
-    "tag": "git tag v$npm_package_version && git push origin v$npm_package_version",
-    "retag": "git tag -f v$npm_package_version && git push -f origin v$npm_package_version",
-    "publish:npm": "npm publish",
-    "prepublishOnly": "npm run clean && npm run build"
-  },
-  "keywords": [
-    "algorand",
-    "mcp",
-    "blockchain",
-    "model-context-protocol"
-  ],
-  "author": "",
-  "license": "MIT",
-  "bin": {
-    "algorand-mcp": "./dist/index.js"
-  },
-  "main": "dist/index.js",
-  "types": "dist/index.d.ts",
-  "files": [
-    "dist/**/*",
-    "README.md"
-  ],
-  "devDependencies": {
-    "@jest/globals": "^30.2.0",
-    "@types/jest": "29.5.12",
-    "@types/node": "^20.0.0",
-    "@types/qrcode": "^1.5.5",
-    "@types/sql.js": "^1.4.9",
-    "jest": "29.7.0",
-    "ts-jest": "29.1.2",
-    "typescript": "^5.0.0"
-  },
-  "dependencies": {
-    "@alpha-arcade/sdk": "latest",
-    "@cf-wasm/photon": "^0.1.31",
-    "@juit/qrcode": "^1.0.59",
-    "@modelcontextprotocol/sdk": "^1.27.1",
-    "@napi-rs/keyring": "^1.2.0",
-    "@noble/curves": "^2.0.1",
-    "@tinymanorg/tinyman-js-sdk": "^5.1.2",
-    "@txnlab/haystack-router": "^2.0.5",
-    "algo-msgpack-with-bigint": "^2.1.1",
-    "algosdk": "^3.5.2",
-    "hi-base32": "^0.5.1",
-    "just-pick": "^4.2.0",
-    "qrcode": "^1.5.4",
-    "sql.js": "^1.14.0",
-    "zod": "^3.25.61"
-  }
+    "name":  "@goplausible/algorand-mcp",
+    "version":  "4.2.5",
+    "repository":  {
+                       "type":  "git",
+                       "url":  "git+https://github.com/GoPlausible/algorand-mcp.git"
+                   },
+    "bugs":  {
+                 "url":  "https://github.com/GoPlausible/algorand-mcp/issues"
+             },
+    "homepage":  "https://github.com/GoPlausible/algorand-mcp#readme",
+    "publishConfig":  {
+                          "access":  "public"
+                      },
+    "description":  "Algorand Model Context Protocol Local Implementation",
+    "type":  "module",
+    "scripts":  {
+                    "build":  "tsc \u0026\u0026 cp -r src/resources/knowledge/taxonomy src/resources/knowledge/taxonomy-categories dist/resources/knowledge/ \u0026\u0026 chmod +x dist/index.js",
+                    "clean":  "rm -rf dist",
+                    "test":  "NODE_OPTIONS=\u0027--experimental-vm-modules\u0027 jest",
+                    "test:e2e":  "NODE_OPTIONS=\u0027--experimental-vm-modules\u0027 jest --config tests/jest.config.e2e.js",
+                    "test:all":  "npm test \u0026\u0026 npm run test:e2e",
+                    "typecheck":  "tsc --noEmit",
+                    "tag":  "git tag v$npm_package_version \u0026\u0026 git push origin v$npm_package_version",
+                    "retag":  "git tag -f v$npm_package_version \u0026\u0026 git push -f origin v$npm_package_version",
+                    "publish:npm":  "npm publish",
+                    "prepublishOnly":  "npm run clean \u0026\u0026 npm run build"
+                },
+    "keywords":  [
+                     "algorand",
+                     "mcp",
+                     "blockchain",
+                     "model-context-protocol"
+                 ],
+    "author":  "",
+    "license":  "MIT",
+    "bin":  {
+                "algorand-mcp":  "./dist/index.js"
+            },
+    "main":  "dist/index.js",
+    "types":  "dist/index.d.ts",
+    "files":  [
+                  "dist/**/*",
+                  "README.md"
+              ],
+    "devDependencies":  {
+                            "@jest/globals":  "^30.2.0",
+                            "@types/jest":  "29.5.12",
+                            "@types/node":  "^20.0.0",
+                            "@types/qrcode":  "^1.5.5",
+                            "@types/sql.js":  "^1.4.9",
+                            "jest":  "29.7.0",
+                            "ts-jest":  "29.1.2",
+                            "typescript":  "^5.0.0"
+                        },
+    "dependencies":  {
+                         "@alpha-arcade/sdk":  "latest",
+                         "@cf-wasm/photon":  "^0.1.31",
+                         "@juit/qrcode":  "^1.0.59",
+                         "@modelcontextprotocol/sdk":  "^1.27.1",
+                         "@napi-rs/keyring":  "^1.2.0",
+                         "@noble/curves":  "^2.0.1",
+                         "@tinymanorg/tinyman-js-sdk":  "^5.1.2",
+                         "@txnlab/haystack-router":  "^2.0.5",
+                         "algo-msgpack-with-bigint":  "^2.1.1",
+                         "algosdk":  "^3.5.2",
+                         "hi-base32":  "^0.5.1",
+                         "just-pick":  "^4.2.0",
+                         "qrcode":  "^1.5.4",
+                         "sql.js":  "^1.14.0",
+                         "zod":  "^3.25.61"
+                     }
 }

--- a/package.json
+++ b/package.json
@@ -1,73 +1,72 @@
 {
-    "name":  "@goplausible/algorand-mcp",
-    "version":  "4.2.5",
-    "repository":  {
-                       "type":  "git",
-                       "url":  "git+https://github.com/GoPlausible/algorand-mcp.git"
-                   },
-    "bugs":  {
-                 "url":  "https://github.com/GoPlausible/algorand-mcp/issues"
-             },
-    "homepage":  "https://github.com/GoPlausible/algorand-mcp#readme",
-    "publishConfig":  {
-                          "access":  "public"
-                      },
-    "description":  "Algorand Model Context Protocol Local Implementation",
-    "type":  "module",
-    "scripts":  {
-                    "build":  "tsc \u0026\u0026 cp -r src/resources/knowledge/taxonomy src/resources/knowledge/taxonomy-categories dist/resources/knowledge/ \u0026\u0026 chmod +x dist/index.js",
-                    "clean":  "rm -rf dist",
-                    "test":  "NODE_OPTIONS=\u0027--experimental-vm-modules\u0027 jest",
-                    "test:e2e":  "NODE_OPTIONS=\u0027--experimental-vm-modules\u0027 jest --config tests/jest.config.e2e.js",
-                    "test:all":  "npm test \u0026\u0026 npm run test:e2e",
-                    "typecheck":  "tsc --noEmit",
-                    "tag":  "git tag v$npm_package_version \u0026\u0026 git push origin v$npm_package_version",
-                    "retag":  "git tag -f v$npm_package_version \u0026\u0026 git push -f origin v$npm_package_version",
-                    "publish:npm":  "npm publish",
-                    "prepublishOnly":  "npm run clean \u0026\u0026 npm run build"
-                },
-    "keywords":  [
-                     "algorand",
-                     "mcp",
-                     "blockchain",
-                     "model-context-protocol"
-                 ],
-    "author":  "",
-    "license":  "MIT",
-    "bin":  {
-                "algorand-mcp":  "./dist/index.js"
-            },
-    "main":  "dist/index.js",
-    "types":  "dist/index.d.ts",
-    "files":  [
-                  "dist/**/*",
-                  "README.md"
-              ],
-    "devDependencies":  {
-                            "@jest/globals":  "^30.2.0",
-                            "@types/jest":  "29.5.12",
-                            "@types/node":  "^20.0.0",
-                            "@types/qrcode":  "^1.5.5",
-                            "@types/sql.js":  "^1.4.9",
-                            "jest":  "29.7.0",
-                            "ts-jest":  "29.1.2",
-                            "typescript":  "^5.0.0"
-                        },
-    "dependencies":  {
-                         "@alpha-arcade/sdk":  "latest",
-                         "@cf-wasm/photon":  "^0.1.31",
-                         "@juit/qrcode":  "^1.0.59",
-                         "@modelcontextprotocol/sdk":  "^1.27.1",
-                         "@napi-rs/keyring":  "^1.2.0",
-                         "@noble/curves":  "^2.0.1",
-                         "@tinymanorg/tinyman-js-sdk":  "^5.1.2",
-                         "@txnlab/haystack-router":  "^2.0.5",
-                         "algo-msgpack-with-bigint":  "^2.1.1",
-                         "algosdk":  "^3.5.2",
-                         "hi-base32":  "^0.5.1",
-                         "just-pick":  "^4.2.0",
-                         "qrcode":  "^1.5.4",
-                         "sql.js":  "^1.14.0",
-                         "zod":  "^3.25.61"
-                     }
+  "name": "@goplausible/algorand-mcp",
+  "version": "4.2.5",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/GoPlausible/algorand-mcp.git"
+  },
+  "bugs": {
+    "url": "https://github.com/GoPlausible/algorand-mcp/issues"
+  },
+  "homepage": "https://github.com/GoPlausible/algorand-mcp#readme",  "publishConfig": {
+    "access": "public"
+  },
+  "description": "Algorand Model Context Protocol Local Implementation",
+  "type": "module",
+  "scripts": {
+    "build": "tsc && cp -r src/resources/knowledge/taxonomy src/resources/knowledge/taxonomy-categories dist/resources/knowledge/ && chmod +x dist/index.js",
+    "clean": "rm -rf dist",
+    "test": "NODE_OPTIONS='--experimental-vm-modules' jest",
+    "test:e2e": "NODE_OPTIONS='--experimental-vm-modules' jest --config tests/jest.config.e2e.js",
+    "test:all": "npm test && npm run test:e2e",
+    "typecheck": "tsc --noEmit",
+    "tag": "git tag v$npm_package_version && git push origin v$npm_package_version",
+    "retag": "git tag -f v$npm_package_version && git push -f origin v$npm_package_version",
+    "publish:npm": "npm publish",
+    "prepublishOnly": "npm run clean && npm run build"
+  },
+  "keywords": [
+    "algorand",
+    "mcp",
+    "blockchain",
+    "model-context-protocol"
+  ],
+  "author": "",
+  "license": "MIT",
+  "bin": {
+    "algorand-mcp": "./dist/index.js"
+  },
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "files": [
+    "dist/**/*",
+    "README.md"
+  ],
+  "devDependencies": {
+    "@jest/globals": "^30.2.0",
+    "@types/jest": "29.5.12",
+    "@types/node": "^20.0.0",
+    "@types/qrcode": "^1.5.5",
+    "@types/sql.js": "^1.4.9",
+    "jest": "29.7.0",
+    "ts-jest": "29.1.2",
+    "typescript": "^5.0.0"
+  },
+  "dependencies": {
+    "@alpha-arcade/sdk": "latest",
+    "@cf-wasm/photon": "^0.1.31",
+    "@juit/qrcode": "^1.0.59",
+    "@modelcontextprotocol/sdk": "^1.27.1",
+    "@napi-rs/keyring": "^1.2.0",
+    "@noble/curves": "^2.0.1",
+    "@tinymanorg/tinyman-js-sdk": "^5.1.2",
+    "@txnlab/haystack-router": "^2.0.5",
+    "algo-msgpack-with-bigint": "^2.1.1",
+    "algosdk": "^3.5.2",
+    "hi-base32": "^0.5.1",
+    "just-pick": "^4.2.0",
+    "qrcode": "^1.5.4",
+    "sql.js": "^1.14.0",
+    "zod": "^3.25.61"
+  }
 }


### PR DESCRIPTION
## Summary
- add npm package source metadata for repository, issue tracker, and homepage
- keep the change scoped to package.json metadata only

## Validation
- decoded package.json from the branch via GitHub API
- parsed package.json successfully after the edit
- verified repository, bugs, and homepage fields point to this public repo